### PR TITLE
RemoteIPが書かれていない場合は通信先の制限をなくすように

### DIFF
--- a/cmd/cnet/main.go
+++ b/cmd/cnet/main.go
@@ -143,7 +143,7 @@ func main() {
 			containers = append(containers, container)
 
 			// Reload security policy data
-			policies, err = policy.ParseSecurityPolicy(policyPath, containers)
+			policies, err = policy.ParseSecurityPolicy(policyPath)
 			if err != nil {
 				logrus.Fatalln(err)
 			}
@@ -156,7 +156,7 @@ func main() {
 		case p := <-packets:
 			logrus.WithField("packet", p).Debug("packet received")
 			var (
-				targetSocket    *proc.Socket
+				targetSocket          *proc.Socket
 				communicatedContainer *container.Container
 				communicatedProcess   *proc.Process
 			)

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -39,7 +39,7 @@ func (s *Socket) IsMatched(x *proc.Socket) bool {
 		return false
 	} else if !bytes.Equal(s.RemoteIP.Mask, net.IPMask{}) && !s.RemoteIP.Contains(x.RemoteIP) {
 		return false
-	} else if !s.RemoteIP.IP.Equal(x.RemoteIP) {
+	} else if !bytes.Equal(s.RemoteIP.IP, net.IP{}) && !s.RemoteIP.IP.Equal(x.RemoteIP) {
 		return false
 	}
 	return true


### PR DESCRIPTION
RemoteIPが書かれていない場合は全ての通信先との通信を許可したいので判定方法を変更しました。
また、引数がおかしい関数が合ったので修正しました

判定方法を `==`使ってもよかったんですがすでにある書き方と合わせました

Fixed #10

CIが落ちている:pien: