### PR TITLE
CIがエラーを吐いていた修正

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Go 1.14.7
+      - name: Set up Go 1.15.3
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.14.7
+          go-version: ^1.15.3
         id: go
 
       - name: cache
@@ -35,13 +35,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: install dependencies
         run: sudo apt update && sudo apt install build-essential libnetfilter-queue-dev libnfnetlink-dev
-      - name: Set up Go 1.14.7
+      - name: Set up Go 1.15.3
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.14.7
+          go-version: ^1.15.3
         id: go
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1.2.1
+        uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.26
+          version: v1.29
           args: --enable=golint,gosec,prealloc,gocognit


### PR DESCRIPTION
```
 Error: Unable to process command '::set-env name=GOROOT::/opt/hostedtoolcache/go/1.15.4/x64' successfully.
  Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
  Error: Unable to process command '::add-path::/opt/hostedtoolcache/go/1.15.4/x64/bin' successfully.
  Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

というエラーをCIが吐いていて、どうやらgithub actionsで非推奨になったものがあるみたいです。
直接的に使用している覚えがないのでライブラリのアップデートで治るんじゃないか(適当)って感じです

何が原因か最初不明だったので、ついでにGoのバージョンを1.15.3へ上げました(本来別のPRに分けるべきですね、すいません)

直接的な解決策としてはgolangci-lintのバージョンを最新版(v.1.2.9)へ更新することで解決しました