### PR TITLE
ログが出力される前にログファイルを設定する

### DIFF
--- a/cmd/cnet/deinit.go
+++ b/cmd/cnet/deinit.go
@@ -12,17 +12,16 @@ func deinit() {
 	}
 	logrus.WithFields(logrus.Fields{
 		"chain_name": chainName,
-		"protocol": protocol,
-		"rule_num": ruleNum,
-		"queue_num": queueNum,
+		"protocol":   protocol,
+		"rule_num":   ruleNum,
+		"queue_num":  queueNum,
 	}).Info("the nfqueue rule deleted")
 
+	logrus.WithField("logfile", logFile).Infoln("cnet quits")
 	if !debug {
 		err = logFile.Close()
 		if err != nil {
 			logrus.WithField("error", err).Error("failed to close log file")
 		}
 	}
-
-	logrus.WithField("logfile", logFile).Infoln("cnet quits")
 }


### PR DESCRIPTION
- ログファイルが設定される前に処理を行い、ログを吐かれている部分があったのでログファイルを一番最初に設定するように変更
- `logrus.WithField("logfile", logFile).Infoln("cnet quits")`をlogFileを閉じるより前に出力することでログファイル内へ出力するように. logfileの閉じ失敗もログファイル内へ出力する
