### PR TITLE
[WIP]SIGINTを受け取ったときにpackets channelを閉じるように

### DIFF
--- a/cmd/cnet/cnet.go
+++ b/cmd/cnet/cnet.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/masibw/go-netfilter-queue"
 	"github.com/tomo-9925/cnet/pkg/container"
 	"github.com/tomo-9925/cnet/pkg/policy"
 )
@@ -32,4 +33,5 @@ var (
 	containers []*container.Container
 	policies   policy.Policies
 	logLevel   logrus.Level
+	queue      *netfilter.NFQueue
 )

--- a/cmd/cnet/deinit.go
+++ b/cmd/cnet/deinit.go
@@ -2,19 +2,15 @@ package main
 
 import (
 	"github.com/sirupsen/logrus"
-	"github.com/tomo-9925/cnet/pkg/network"
 )
 
 func deinit() {
-	err = network.DeleteNFQueueRule(chainName, protocol, queueNum)
-	if err != nil {
-		logrus.WithField("error", err).Error("failed to delete the nfqueue rule")
-	}
+	queue.Close()
 	logrus.WithFields(logrus.Fields{
 		"chain_name": chainName,
-		"protocol": protocol,
-		"rule_num": ruleNum,
-		"queue_num": queueNum,
+		"protocol":   protocol,
+		"rule_num":   ruleNum,
+		"queue_num":  queueNum,
 	}).Info("the nfqueue rule deleted")
 
 	if !debug {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/google/go-cmp v0.5.3
 	github.com/google/gopacket v1.1.19
+	github.com/masibw/go-netfilter-queue v0.0.0-20201212105114-06c1993e5dd0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/masibw/go-netfilter-queue v0.0.0-20201212105114-06c1993e5dd0 h1:nVL1MBCA3Jwc/YFSNEx+PUTM9+zpISYGEC4W7A48Rrs=
+github.com/masibw/go-netfilter-queue v0.0.0-20201212105114-06c1993e5dd0/go.mod h1:QRRVv1BDfd4RUYE5wE3KKWa3z+TxOORt4L7b3zeuNuQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -48,8 +50,6 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba h1:xmhUJGQGbxlod18iJGqVEp9cHIPLl7QiX2aA3to708s=
 golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201118182958-a01c418693c7 h1:Z991aAXPjz0tLnj74pVXW3eWJ5lHMIBvbRfMq4M2jHA=
-golang.org/x/sys v0.0.0-20201118182958-a01c418693c7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
#16 の修正です.

# 再現方法
継続的にdrop対象のパケットが送られてきている状態でSIGINTを送ると処理がストップします.

例)
`curl サーバーIP {cnetで拒否設定のポート}`
をしている状態で`ctrl+c`により終了しようとしてもsignalを受け取った後進まなくなる

# 原因
nfqueueが使用しているchanを閉じていなかった.

# 対処法
`queue.GetPackets()`で得られるチャンネルは受信専用であり,closeすることができない(送信側からcloseする必要がある)
[ライブラリ](https://github.com/AkihiroSuda/go-netfilter-queue)には後片付け用の`Close()`があるがチャンネルのcloseを行っていない(おそらくバグ)
そのため[上記ライブラリをForkして書き換えたもの](https://github.com/masibw/go-netfilter-queue)を使用するように変更しました

一応PRを送りますが、長らくメンテナンスされていないライブラリなのでどうなるかわかりません


治ったと思ったら治らなくてぴえんです