### PR TITLE
queue.Close()を呼ばないように

### DIFF
--- a/cmd/cnet/main.go
+++ b/cmd/cnet/main.go
@@ -22,7 +22,6 @@ func main() {
 	if err != nil {
 		logrus.WithField("error", err).Fatal("failed to bind nfqueue")
 	}
-	logrus.DeferExitHandler(queue.Close)
 	packets := queue.GetPackets()
 
 	runCh := make(chan string)
@@ -40,8 +39,8 @@ func main() {
 			//Include newly launched containers in the monitoring
 			containerFields := logrus.WithFields(logrus.Fields{
 				"container_id": cid,
-				"containers": containers,
-				})
+				"containers":   containers,
+			})
 			container, err := container.FetchDockerContainerInspection(cid)
 			if err != nil {
 				containerFields.WithField("error", err).Fatal("failed to fetch docker container inspection")
@@ -60,8 +59,8 @@ func main() {
 			container.RemoveContainerFromSlice(containers, cid)
 			logrus.WithFields(logrus.Fields{
 				"container_id": cid,
-				"containers": containers,
-				}).Info("container information removed")
+				"containers":   containers,
+			}).Info("container information removed")
 		case cid := <-runErrCh:
 			logrus.WithField("container_id", cid).Info("an error occurred when starting the container")
 		case p := <-packets:
@@ -81,9 +80,9 @@ func main() {
 			if err != nil {
 				p.SetVerdict(netfilter.NF_DROP)
 				logrus.WithField("error", err).WithFields(logrus.Fields{
-					"target_socket": targetSocket,
+					"target_socket":          targetSocket,
 					"communicated_container": communicatedContainer,
-					}).Warn("the packet with unidentified process dropped")
+				}).Warn("the packet with unidentified process dropped")
 				continue
 			}
 			communicationFields := logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
(おそらく)本当の #16 の解決策です

# 原因
`queue.Close()`の内部で以下のようにprintデバッグしたところ
```
//Unbind and close the queue
func (nfq *NFQueue) Close() {
	fmt.Println("Close top")
	C.nfq_destroy_queue(nfq.qh)
	fmt.Println("after nfq_destroy_queue")
	C.nfq_close(nfq.h)
	fmt.Println("after nfq_close")
	theTabeLock.Lock()
	close(nfq.packets)
	fmt.Println("after close packets")
	delete(theTable, nfq.idx)
	fmt.Println("after delete thetable")
	theTabeLock.Unlock()
	fmt.Println("after unlock")
}
```

```
^CINFO[2020-12-13T05:20:45Z] the signal received                           signal=interrupt
Close top
```
と出ました。なので`go-netfilter-queue`の`C.nfq_destroy_queue(nfq.qh)`が原因のようです。
しかし、この部分はC言語での実装をGoで呼び出している部分でありそのコードは[こちら](https://git.netfilter.org/libnetfilter_queue/)です。

これを読み解き・改善したところで`go-netfilter-queue`で改善したものを読み取るようにして自分たちで使うのはかなり難しいですし割りに合わないと思います...

強制終了に近い形になるのでメモリが解放されるかなどの懸念はありますが,現状は単にこの関数を使わないのがベストかなと思いました...
